### PR TITLE
Fix broken instruction tour display

### DIFF
--- a/game/static/game/js/home.js
+++ b/game/static/game/js/home.js
@@ -2777,7 +2777,14 @@ class OnboardingTour {
 let onboardingTour;
 
 document.addEventListener('DOMContentLoaded', () => {
-    initializeTimer();
+    // Only initialize tour on pages with main game container
+    if (!document.getElementById('game-main')) return;
+
+    // initializeTimer is defined inside the main game bootstrapping scope
+    if (typeof initializeTimer === 'function') {
+        initializeTimer();
+    }
+
     // Wait for other systems to load first
     setTimeout(() => {
         onboardingTour = new OnboardingTour();

--- a/game/templates/game/base.html
+++ b/game/templates/game/base.html
@@ -2644,7 +2644,7 @@
     </script>
 
     <!-- Game logic script -->
-    <script src="{% static 'game/js/home.js' %}?v=155" defer></script>
+    <script src="{% static 'game/js/home.js' %}?v=156" defer></script>
 {% endblock %}
 
 


### PR DESCRIPTION
Fixes instruction tour not showing by guarding its initialization and updating the static file version.

The tour's initialization was failing due to a `ReferenceError` when `initializeTimer()` was called on pages where it was not defined, preventing the tour from ever being created. This PR ensures the tour only initializes on the game page and safely calls `initializeTimer()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-72892311-f625-41a0-a126-6378201bdf55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72892311-f625-41a0-a126-6378201bdf55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

